### PR TITLE
Memory optimization

### DIFF
--- a/include/otbObiaGraph.txx
+++ b/include/otbObiaGraph.txx
@@ -342,6 +342,9 @@ Graph<TNode>::RemoveNodes()
     });
 
     m_Nodes.erase(eraseIt, m_Nodes.end());
+    
+    // Need to call this method to reduce the memory usage.
+    m_Nodes.shrink_to_fit();
 
     auto lambdaDecrementIdEdge = [&numMergedNodes](EdgeType& edge){
         edge.m_TargetId = edge.m_TargetId - numMergedNodes[edge.m_TargetId];


### PR DESCRIPTION
Bonsoir Julien,

J'ai fait un profiling du code avec valgrind en utilisant l'outil massif. Je me suis rendu compte que les noeuds qui ont fusionné n'était pas supprimés de la mémoire. J'ai alors rajouté dans le fichier otbObiaGraph.txx dans la fonction RemoveNodes() un appel à la méthode shrink_to_fit() après l'appel à erase() pour forcer la désallocation mémoire. En effectuant un nouveau profiling, le résultat est sans appel car cette fois-ci la mémoire est réellement libérée.
Le fichier Profile.txt te montre la conso mémoire sans la modification.
Le fichier Profile1.txt te montre la conso mémoire avec cette modification.
[Profile.txt](https://github.com/RTOBIA/LSOBIA/files/1545827/Profile.txt)
[Profile1.txt](https://github.com/RTOBIA/LSOBIA/files/1545828/Profile1.txt)

Bonne soirée.

