### PR TITLE
Everything up-to-date and working

### DIFF
--- a/include/otbObiaBaatzSegmentationFilter.h
+++ b/include/otbObiaBaatzSegmentationFilter.h
@@ -85,7 +85,7 @@ public:
      * \param: NodeIn
      * \param: NodeOut
      * \return : return true if the merging cost is required*/
-    ValueType ComputeMergingCost(NodeType* NodeIn, NodeType* NodeOut);
+    ValueType ComputeMergingCost(NodeType* NodeIn, NodeType* NodeOut); // TODO: should be const
 protected:
 
     /**\brief Maximal cost of merging*/

--- a/include/otbObiaBaatzSegmentationFilter.txx
+++ b/include/otbObiaBaatzSegmentationFilter.txx
@@ -36,7 +36,7 @@ BaatzMergingCost<TCost, TGraph>::ComputeMergingCostsForThisAdjNode(const NodeTyp
 
 template< typename TCost, typename TGraph >
 typename BaatzMergingCost< TCost, TGraph>::ValueType
-BaatzMergingCost<TCost, TGraph>::ComputeMergingCost(NodeType* n1, NodeType* n2)
+BaatzMergingCost<TCost, TGraph>::ComputeMergingCost(NodeType* n1, NodeType* n2)  // TODO: should be const
 {
     // Retrieve attributes
     const float aArea = n1->m_Attributes.m_Area;
@@ -45,10 +45,11 @@ BaatzMergingCost<TCost, TGraph>::ComputeMergingCost(NodeType* n1, NodeType* n2)
     
     float colorH = 0.0f;
 
-    if(m_BandWeights.size() < 1)
-    {
-        m_BandWeights.assign(n1->m_Attributes.m_AvgSpec.size(), 1.0f);
-    }
+    // TODO: No. We should do this elsewhere!
+   //    if(m_BandWeights.size() < 1)
+   //    {
+   //        m_BandWeights.assign(n1->m_Attributes.m_AvgSpec.size(), 1.0f);
+   //    }
 
     for (uint32_t band = 0; band < n1->m_Attributes.m_AvgSpec.size(); band++)
     {
@@ -66,7 +67,13 @@ BaatzMergingCost<TCost, TGraph>::ComputeMergingCost(NodeType* n1, NodeType* n2)
         stddev = std::sqrt(stddevTmp / areaSum);
         colorF = n1->m_Attributes.m_Area * n1->m_Attributes.m_StdSpec[band] + n2->m_Attributes.m_Area * n2->m_Attributes.m_StdSpec[band];
 
-        colorF = m_BandWeights[band] * ((areaSum * stddev) - colorF);
+        // TODO: replace it, when m_BandWeights will be properly set elsewhere
+//     colorF = m_BandWeights[band] * ((areaSum * stddev) - colorF);
+       colorF = ((areaSum * stddev) - colorF);
+
+
+
+
         colorH += colorF;
 
     }

--- a/include/otbObiaGenericRegionMergingFilter.h
+++ b/include/otbObiaGenericRegionMergingFilter.h
@@ -1,11 +1,8 @@
 #ifndef __otbObiaGenericRegionMergingFilter_h
 #define __otbObiaGenericRegionMergingFilter_h
+#include "otbObiaGraph.h"
 #include "otbObiaGraphToGraphFilter.h"
-
-/**
-\file otbObiaGenericRegionMergingFilter.h
-\brief This file define the generic filter used to compute a segmentation using Baatz & Schäpe or to merge small regions
-*/
+#include "itkProgressReporter.h"
 
 namespace otb
 {
@@ -13,115 +10,102 @@ namespace otb
 namespace obia
 {
 
-/**\class GenericRegionMergingFilter otbObiaGenericRegionMergingFilter.h
- * \brief Class defining the generic filter.
- * It is templated by:
- * - An input graph type (like Baatz graph)
- * - An output graph type (generally same as input)
- * - A merging cost func, used to describe the cost between nodes in order to decide when to merge
- * - An heuristic func use to decide which node is the best adjacent node in a graph
- * - An update attribute func used to update meta data of merged node (like area, mean, etc ...)\n*/
 template< typename TInputGraph,
-          typename TOutputGraph,
-          typename TMergingCostFunc,
-          typename THeuristic,
-          typename TUpdateAttributeFunc >
+		  typename TOutputGraph,
+		  typename TMergingCostFunc,
+		  typename THeuristic,
+		  typename TUpdateAttributeFunc >
 class GenericRegionMergingFilter : public GraphToGraphFilter<TInputGraph, TInputGraph>
 {
+
 public:
 
-    /** Standard convenient alias */
-    using Self = GenericRegionMergingFilter;
-    using Superclass = GraphToGraphFilter<TInputGraph, TInputGraph>;
-    using Pointer = itk::SmartPointer<Self>;
-    using ConstPointer = itk::SmartPointer< const Self>;
+	/** Standard convenient alias */
+	using Self = GenericRegionMergingFilter;
+	using Superclass = GraphToGraphFilter<TInputGraph, TInputGraph>;
+	using Pointer = itk::SmartPointer<Self>;
+	using ConstPointer = itk::SmartPointer< const Self>;
 
-    /** Some convenient alias */
-    using InputGraphType  = TInputGraph;
-    using OutputGraphType = TOutputGraph;
-    using NodeType          = typename InputGraphType::NodeType;
-    /** 
-        Some convenient alias concerning the type of the function
-        which computes the merging cost.
-    */
-    using MergingCostFunctionType = TMergingCostFunc;
-    using MergingCostValueType = typename MergingCostFunctionType::ValueType;
-    using HeuristicType = THeuristic;
-    using UpdateAttributeFuncType = TUpdateAttributeFunc;
-
-
-    /**\brief Method for creation through the object factory. */
-    itkNewMacro(Self);
-
-    /** Run-time type information (and related methods). */
-    itkTypeMacro(GenericRegionMergingFilter, GraphToGraphFilter);
-
-    itkSetMacro(MaxNumberOfIterations, unsigned int);
-    itkGetMacro(MergingOver, bool);
-    itkGetMacro(AppliedNumberOfIterations, unsigned int);
-
-    itkGetMacro(MergingCostFunc, MergingCostFunctionType *);
-
-    itkGetMacro(HeuristicFunc, HeuristicType *);
-
-    itkGetMacro(UpdateAttributeFunc, UpdateAttributeFuncType *);
-
-    /**\brief Set the merging cost func
-     * \param Merging cost function*/
-    void SetMergingCostFunc(MergingCostFunctionType * mergingCost){m_MergingCostFunc = mergingCost;};
-
-    /**\brief Set the heuristic cost func
-     * \param Heuristic function*/
-    void SetHeuristicFunc(HeuristicType * heuristicFunc){m_HeuristicFunc = heuristicFunc;};
-
-    /**\brief Set the update attribute func
-     * \param Update attribute func*/
-    void SetUpdateAttributeFunc(UpdateAttributeFuncType * updateAttribute){m_UpdateAttributeFunc = updateAttribute;};
-
-    /**\brief Check validity of the object, it checks if the 3 required functions are set (not nullptr)*/
-    virtual void CheckValidity();
-protected:
-
-    GenericRegionMergingFilter();
-    virtual ~GenericRegionMergingFilter();
-
-    void PrintSelf(std::ostream & os, itk::Indent indent) const ITK_OVERRIDE;
-
-    void GenerateData();
-
-    /** \briefGeneric method applying one iteration of a region merging procedure
-        Can be override by inherited classes for very specific cases.
-    */
-    virtual bool DoOneIteration();
-
-    /**\brief Generic method that merges two adjacent nodes.
-     * \param: Node in
-     * \param: Node out which will merge with node in
-    */
-    virtual void Merge(NodeType* nodeIn, NodeType * nodeOut);
-
-    /**\brief Generic method computing the merging cost between pair of adjacent
-        nodes in an adjacent graph.
-        Can be override by inherited classes for specific cases.
-    */
-    virtual void ComputeMergingCosts();
+	/** Some convenient alias */
+	using InputGraphType  = TInputGraph;
+	using OutputGraphType = TOutputGraph;
+	using NodeType		  = typename InputGraphType::NodeType;
+	/** 
+		Some convenient alias concerning the type of the function
+		which computes the merging cost.
+	*/
+	using MergingCostFunctionType = TMergingCostFunc;
+	using MergingCostValueType = typename MergingCostFunctionType::ValueType;
+	using HeuristicType = THeuristic;
+	using UpdateAttributeFuncType = TUpdateAttributeFunc;
 
 
-private:
+	/** Method for creation through the object factory. */
+  	itkNewMacro(Self);
 
-    /**\brief For a region merging process, there will be always a maximum number of iterations. */
-    unsigned int m_MaxNumberOfIterations;
+	/** Run-time type information (and related methods). */
+  	itkTypeMacro(GraphToGraphFilter, GraphSource);
 
-    /**\brief Real number of iterations done. */
-    unsigned int m_AppliedNumberOfIterations;
+  	itkSetMacro(MaxNumberOfIterations, unsigned int);
+  	itkGetMacro(MergingOver, bool);
+  	itkGetMacro(AppliedNumberOfIterations, unsigned int);
 
-    /*\brief It will be always necessary to know if there has been merges during the last iteration. */
-    bool m_MergingOver;
+  	itkGetMacro(MergingCostFunc, MergingCostFunctionType *);
+  	//itkSetMacro(MergingCostFunc, MergingCostFunctionType *);
 
-    /** Pointers to functions that needs to be specialized */
-    MergingCostFunctionType * m_MergingCostFunc;
-    HeuristicType * m_HeuristicFunc;
-    UpdateAttributeFuncType * m_UpdateAttributeFunc;
+  	itkGetMacro(HeuristicFunc, HeuristicType *);
+  	//itkSetMacro(HeuristicFunc, HeuristicType *);
+
+  	itkGetMacro(UpdateAttributeFunc, UpdateAttributeFuncType *);
+  	//itkSetMacro(UpdateAttributeFunc, UpdateAttributeFuncType *);
+
+  	void SetMergingCostFunc(MergingCostFunctionType * mergingCost){m_MergingCostFunc = mergingCost;};
+  	void SetHeuristicFunc(HeuristicType * heuristicFunc){m_HeuristicFunc = heuristicFunc;};
+  	void SetUpdateAttributeFunc(UpdateAttributeFuncType * updateAttribute){m_UpdateAttributeFunc = updateAttribute;};
+
+	/**Check validity of the object*/
+  	virtual void CheckValidity();
+  protected:
+
+  	GenericRegionMergingFilter();
+  	virtual ~GenericRegionMergingFilter();
+
+  	void PrintSelf(std::ostream & os, itk::Indent indent) const ITK_OVERRIDE;
+
+  	void GenerateData();
+
+  	/** 
+  		Generic method applying one iteration of a region merging procedure
+  		Can be override by inherited classes for very specific cases.
+  	*/
+  	virtual bool DoOneIteration();
+
+  	/**
+  		Generic method computing the merging cost between pair of adjacent
+  		nodes in an adjacent graph.
+  		Can be override by inherited classes for specific cases.
+  	*/
+  	virtual void ComputeMergingCosts();
+
+  private:
+
+  	/** For a region merging process, there will be always a maximum number of iterations. */
+  	unsigned int m_MaxNumberOfIterations;
+
+  	/** Real number of iterations done. */
+  	unsigned int m_AppliedNumberOfIterations;
+
+  	/** It will be always necessary to know if there has been merges during the last iteration. */
+  	bool m_MergingOver;
+
+  	/** Pointers to functions that needs to be specialized */
+  	MergingCostFunctionType * m_MergingCostFunc;
+  	HeuristicType * m_HeuristicFunc;
+  	UpdateAttributeFuncType * m_UpdateAttributeFunc;
+
+  	/** timings (benchmarks) */
+  	std::vector<float>         timingsValues;
+  	std::vector<std::string>   timingsLabels;
 };
 
 

--- a/include/otbObiaGenericRegionMergingFilter.h
+++ b/include/otbObiaGenericRegionMergingFilter.h
@@ -11,101 +11,102 @@ namespace obia
 {
 
 template< typename TInputGraph,
-		  typename TOutputGraph,
-		  typename TMergingCostFunc,
-		  typename THeuristic,
-		  typename TUpdateAttributeFunc >
+typename TOutputGraph,
+typename TMergingCostFunc,
+typename THeuristic,
+typename TUpdateAttributeFunc >
 class GenericRegionMergingFilter : public GraphToGraphFilter<TInputGraph, TInputGraph>
 {
 
 public:
 
-	/** Standard convenient alias */
-	using Self = GenericRegionMergingFilter;
-	using Superclass = GraphToGraphFilter<TInputGraph, TInputGraph>;
-	using Pointer = itk::SmartPointer<Self>;
-	using ConstPointer = itk::SmartPointer< const Self>;
+  /** Standard convenient alias */
+  using Self = GenericRegionMergingFilter;
+  using Superclass = GraphToGraphFilter<TInputGraph, TInputGraph>;
+  using Pointer = itk::SmartPointer<Self>;
+  using ConstPointer = itk::SmartPointer< const Self>;
 
-	/** Some convenient alias */
-	using InputGraphType  = TInputGraph;
-	using OutputGraphType = TOutputGraph;
-	using NodeType		  = typename InputGraphType::NodeType;
-	/** 
+  /** Some convenient alias */
+  using InputGraphType  = TInputGraph;
+  using OutputGraphType = TOutputGraph;
+  using NodeType = typename InputGraphType::NodeType;
+  using EdgeType = typename InputGraphType::EdgeType;
+
+  /**
 		Some convenient alias concerning the type of the function
 		which computes the merging cost.
-	*/
-	using MergingCostFunctionType = TMergingCostFunc;
-	using MergingCostValueType = typename MergingCostFunctionType::ValueType;
-	using HeuristicType = THeuristic;
-	using UpdateAttributeFuncType = TUpdateAttributeFunc;
+   */
+  using MergingCostFunctionType = TMergingCostFunc;
+  using MergingCostValueType = typename MergingCostFunctionType::ValueType;
+  using HeuristicType = THeuristic;
+  using UpdateAttributeFuncType = TUpdateAttributeFunc;
 
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
 
-	/** Method for creation through the object factory. */
-  	itkNewMacro(Self);
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(GraphToGraphFilter, GraphSource);
 
-	/** Run-time type information (and related methods). */
-  	itkTypeMacro(GraphToGraphFilter, GraphSource);
+  itkSetMacro(MaxNumberOfIterations, unsigned int);
+  itkGetMacro(MergingOver, bool);
+  itkGetMacro(AppliedNumberOfIterations, unsigned int);
 
-  	itkSetMacro(MaxNumberOfIterations, unsigned int);
-  	itkGetMacro(MergingOver, bool);
-  	itkGetMacro(AppliedNumberOfIterations, unsigned int);
+  itkGetMacro(MergingCostFunc, MergingCostFunctionType *);
+  //itkSetMacro(MergingCostFunc, MergingCostFunctionType *);
 
-  	itkGetMacro(MergingCostFunc, MergingCostFunctionType *);
-  	//itkSetMacro(MergingCostFunc, MergingCostFunctionType *);
+  itkGetMacro(HeuristicFunc, HeuristicType *);
+  //itkSetMacro(HeuristicFunc, HeuristicType *);
 
-  	itkGetMacro(HeuristicFunc, HeuristicType *);
-  	//itkSetMacro(HeuristicFunc, HeuristicType *);
+  itkGetMacro(UpdateAttributeFunc, UpdateAttributeFuncType *);
+  //itkSetMacro(UpdateAttributeFunc, UpdateAttributeFuncType *);
 
-  	itkGetMacro(UpdateAttributeFunc, UpdateAttributeFuncType *);
-  	//itkSetMacro(UpdateAttributeFunc, UpdateAttributeFuncType *);
+  void SetMergingCostFunc(MergingCostFunctionType * mergingCost){m_MergingCostFunc = mergingCost;};
+  void SetHeuristicFunc(HeuristicType * heuristicFunc){m_HeuristicFunc = heuristicFunc;};
+  void SetUpdateAttributeFunc(UpdateAttributeFuncType * updateAttribute){m_UpdateAttributeFunc = updateAttribute;};
 
-  	void SetMergingCostFunc(MergingCostFunctionType * mergingCost){m_MergingCostFunc = mergingCost;};
-  	void SetHeuristicFunc(HeuristicType * heuristicFunc){m_HeuristicFunc = heuristicFunc;};
-  	void SetUpdateAttributeFunc(UpdateAttributeFuncType * updateAttribute){m_UpdateAttributeFunc = updateAttribute;};
+  /**Check validity of the object*/
+  virtual void CheckValidity();
+protected:
 
-	/**Check validity of the object*/
-  	virtual void CheckValidity();
-  protected:
+  GenericRegionMergingFilter();
+  virtual ~GenericRegionMergingFilter();
 
-  	GenericRegionMergingFilter();
-  	virtual ~GenericRegionMergingFilter();
+  void PrintSelf(std::ostream & os, itk::Indent indent) const ITK_OVERRIDE;
 
-  	void PrintSelf(std::ostream & os, itk::Indent indent) const ITK_OVERRIDE;
+  void GenerateData();
 
-  	void GenerateData();
-
-  	/** 
+  /**
   		Generic method applying one iteration of a region merging procedure
   		Can be override by inherited classes for very specific cases.
-  	*/
-  	virtual bool DoOneIteration();
+   */
+  virtual bool DoOneIteration();
 
-  	/**
+  /**
   		Generic method computing the merging cost between pair of adjacent
   		nodes in an adjacent graph.
   		Can be override by inherited classes for specific cases.
-  	*/
-  	virtual void ComputeMergingCosts();
+   */
+  virtual void ComputeMergingCosts();
 
-  private:
+private:
 
-  	/** For a region merging process, there will be always a maximum number of iterations. */
-  	unsigned int m_MaxNumberOfIterations;
+  /** For a region merging process, there will be always a maximum number of iterations. */
+  unsigned int m_MaxNumberOfIterations;
 
-  	/** Real number of iterations done. */
-  	unsigned int m_AppliedNumberOfIterations;
+  /** Real number of iterations done. */
+  unsigned int m_AppliedNumberOfIterations;
 
-  	/** It will be always necessary to know if there has been merges during the last iteration. */
-  	bool m_MergingOver;
+  /** It will be always necessary to know if there has been merges during the last iteration. */
+  bool m_MergingOver;
 
-  	/** Pointers to functions that needs to be specialized */
-  	MergingCostFunctionType * m_MergingCostFunc;
-  	HeuristicType * m_HeuristicFunc;
-  	UpdateAttributeFuncType * m_UpdateAttributeFunc;
+  /** Pointers to functions that needs to be specialized */
+  MergingCostFunctionType * m_MergingCostFunc;
+  HeuristicType * m_HeuristicFunc;
+  UpdateAttributeFuncType * m_UpdateAttributeFunc;
 
-  	/** timings (benchmarks) */
-  	std::vector<float>         timingsValues;
-  	std::vector<std::string>   timingsLabels;
+  /** timings (benchmarks) */
+  std::vector<float>         timingsValues;
+  std::vector<std::string>   timingsLabels;
 };
 
 

--- a/include/otbObiaGenericRegionMergingFilter.txx
+++ b/include/otbObiaGenericRegionMergingFilter.txx
@@ -1,52 +1,489 @@
 #ifndef __otbObiaGenericRegionMergingFilter_txx
 #define __otbObiaGenericRegionMergingFilter_txx
-
 #include "otbObiaGenericRegionMergingFilter.h"
-
+#include "itkTimeProbe.h"
+#include <thread>
+#include <iostream>
+#include <vector>
 namespace otb
 {
 namespace obia
 {
 
-template< typename TInputGraph, 
-          typename TOutputGraph, 
-          typename TMergingCostFunc, 
-          typename THeuristic, 
-          typename TUpdateAttributeFunc>
+/*
+ * Class to help with threads.
+ * We set the range of elements to process within the array.
+ * This can process:
+ * -nodes
+ * -pairs of nodes
+ *
+ * TODO:
+ * * something cleaner :]
+ * * refactor the call to the worker, including the computation of chunkSize, ranges, ...
+ * * maybe use itk thread classes (don't know if useful?)
+ * * const stuff
+ */
+template<typename TOutputGraph, typename TMergingCostFunc, typename TUpdateAttributeFunc>
+class ThreadWorker
+{
+public:
+
+  ThreadWorker(){};
+  ~ThreadWorker(){};
+
+  void SetGraph(TOutputGraph* graph)
+  {
+    m_OutputGraph = graph;
+  }
+  void SetMergingCostFunc(TMergingCostFunc * mergingCostFunc)
+  {
+    m_MergingCostFunc = mergingCostFunc;
+  }
+  void SetUpdateAttributeFunc(TUpdateAttributeFunc * func)
+  {
+    m_UpdateAttributesFunc = func;
+  }
+  void SetRange(uint64_t istart, uint64_t iend)
+  {
+    m_RangeStart = istart;
+    m_RangeEnd = iend;
+  }
+  void SetPairsOfNodesToProcess(std::vector<std::pair<typename TOutputGraph::NodeType * ,typename TOutputGraph::NodeType * >> &pairs)
+  {
+    m_PairsOfNodesToProcess = pairs;
+  }
+
+  /*
+   * Compute merging costs of the nodes
+   * See "threadsafe.jpg" in the root directory for details.
+   */
+  void ComputeMergingCosts()
+  {
+    uint64_t minNodeId = m_OutputGraph->GetNumberOfNodes()+1, idx, minIdx;
+    typename TMergingCostFunc::ValueType minCost;
+
+    // Loop over the nodes
+    for(auto nodeIt = m_OutputGraph->Begin() + m_RangeStart; nodeIt != m_OutputGraph->Begin() + m_RangeEnd; nodeIt++)
+      {
+      nodeIt->m_ThreadSafe = true;
+      nodeIt->m_ThreadSafeForMerge = true;
+
+      if(m_MergingCostFunc->ComputeMergingCostsForThisNode(&(*nodeIt))
+          && nodeIt->m_Edges.size()>0) // Since the introducing of no-data, a node can be alone
+        {
+
+        // The merging cost function must give the maximum value of the merging cost.
+        minCost = TMergingCostFunc::Max();
+        idx = 0;
+        minIdx = 0;
+        nodeIt->m_HasToBeRemoved = false;
+        nodeIt->m_Valid = true;
+
+        // Loop over the edges
+        for(auto& edgeIt : nodeIt->m_Edges)
+          {
+
+          // Tell if this node has edges targeting nodes which are outside the thread range
+          if ( edgeIt.m_TargetId < m_RangeStart || edgeIt.m_TargetId >= m_RangeEnd )
+            {
+            nodeIt->m_ThreadSafe = false;
+            nodeIt->m_ThreadSafeForMerge = false;
+            }
+
+          // Retrieve the adjacent node.
+          auto adjNode = m_OutputGraph->GetNodeAt(edgeIt.m_TargetId);
+          if(m_MergingCostFunc->ComputeMergingCostsForThisAdjNode(adjNode))
+            {
+
+            // If one of the adjacent nodes
+            // has merged at the previous iteration then we must compute the
+            // merging cost.
+            if(nodeIt->m_Attributes.m_HasPreviouslyMerged || adjNode->m_Attributes.m_HasPreviouslyMerged)
+              {
+              edgeIt.m_Attributes.m_MergingCost = m_MergingCostFunc->ComputeMergingCost(&(*nodeIt), adjNode);
+              }
+
+            // If the current cost is minimum than we record it.
+            if(edgeIt.m_Attributes.m_MergingCost < minCost)
+              {
+              minCost = edgeIt.m_Attributes.m_MergingCost;
+              minNodeId = adjNode->GetFirstPixelCoords();
+              minIdx = idx;
+              }
+
+            // In case of equality, we keep the adjacent node with the lower starting
+            // coordinates.
+            else if(minCost == edgeIt.m_Attributes.m_MergingCost)
+              {
+              if(adjNode->GetFirstPixelCoords() < minNodeId)
+                {
+                minNodeId = adjNode->GetFirstPixelCoords();
+                minIdx = idx;
+                }
+              }
+
+            } // end if(MergingCostFunctionType::ComputeMergingCostsForThisAdjNode(adjNode))
+
+          idx++;
+
+          } // end loop over the edges.
+
+        // Finally we move the adjacent node with the lower merging cost
+        // at the first position in the list of adjacent nodes.
+        std::swap(nodeIt->m_Edges[0], nodeIt->m_Edges[minIdx]);
+
+        } // end if(MergingCostFunctionType::ComputeMergingCostsForThisNode(&(*nodeIt)))
+      } // end for loop over the nodes
+
+    // Grow the thread-unsafe-for-merge region (we know that the merge operation requires to R/W adjacent nodes of
+    // the pair of nodes to merge)
+    for(auto nodeIt = m_OutputGraph->Begin() + m_RangeStart; nodeIt != m_OutputGraph->Begin() + m_RangeEnd; nodeIt++)
+      {
+      if (nodeIt->m_ThreadSafe == false)
+        {
+        for(auto& edgeIt : nodeIt->m_Edges)
+          {
+          if (m_RangeStart <= edgeIt.m_TargetId && edgeIt.m_TargetId < m_RangeEnd)
+            {
+            auto adjNode = m_OutputGraph->GetNodeAt(edgeIt.m_TargetId);
+            adjNode->m_ThreadSafeForMerge = false;
+            }
+          }
+        }
+      }
+
+
+  } // ComputeMergingCosts()
+
+  /*
+   * Reset the merge flag(s) of nodes
+   */
+  void ResetMergeFlags()
+  {
+    for(auto nodeIt = m_OutputGraph->Begin() + m_RangeStart; nodeIt != m_OutputGraph->Begin() + m_RangeEnd; nodeIt++)
+      {
+      nodeIt->m_Attributes.m_HasPreviouslyMerged = false;
+      }
+  } // ResetMergeFlags()
+
+  /*
+   * Performs the merge of pairs in the range [m_RangeStart, m_RangeEnd[
+   */
+  void FusionOfPairs()
+  {
+    for (auto pairIt =  m_PairsOfNodesToProcess.begin() + m_RangeStart ; pairIt != m_PairsOfNodesToProcess.begin() + m_RangeEnd; pairIt++)
+      {
+      typename TOutputGraph::NodeType * nodeIn = pairIt->first;
+      typename TOutputGraph::NodeType * nodeOut = pairIt->second;
+
+      // Update attributes of thread-safe nodes
+      m_UpdateAttributesFunc->UpdateAttributes(nodeIn, nodeOut);
+
+      // Fusion of the bounding box
+      SpatialTools::MergeBoundingBox(nodeIn->m_BoundingBox, nodeOut->m_BoundingBox);
+
+      // Merge the edges
+      m_OutputGraph->MergeEdge(nodeIn, nodeOut);
+
+      // Fusion of the contour
+      nodeIn->m_Contour.MergeWith(nodeOut->m_Contour, m_OutputGraph->GetImageWidth(), m_OutputGraph->GetImageHeight());
+
+      // nodeOut has to be removed, so we mark it as it
+      nodeOut->m_HasToBeRemoved = true;
+      }
+  } // FusionOfPairs()
+
+  /*
+   * Reconditionning of the graph
+   */
+  void Reconditioning()
+  {
+    for(auto nodeIt = m_OutputGraph->Begin() + m_RangeStart; nodeIt != m_OutputGraph->Begin() + m_RangeEnd; nodeIt++)
+    {
+      nodeIt->m_HasToBeRemoved = false;
+      nodeIt->m_Valid = true;
+      nodeIt->m_Attributes.m_HasPreviouslyMerged = true;
+      for(auto& edg : nodeIt->m_Edges)
+      {
+        edg.m_Attributes.m_MergingCost = m_MergingCostFunc->GetMax();
+      }
+    }
+  }
+
+private:
+  TOutputGraph*           m_OutputGraph;
+  TMergingCostFunc *      m_MergingCostFunc;
+  TUpdateAttributeFunc *  m_UpdateAttributesFunc;
+  int64_t                 m_RangeStart;
+  int64_t                 m_RangeEnd;
+  std::vector<std::pair<typename TOutputGraph::NodeType * ,typename TOutputGraph::NodeType * >>
+                          m_PairsOfNodesToProcess;
+
+};
+
+template<typename TOutputGraph, typename TMergingCostFunc, typename TUpdateAttributeFunc>
+void ComputeMergingCostsInRange (TOutputGraph * graph, TMergingCostFunc * mergingCostFunc, uint64_t start, uint64_t end)
+{
+
+  ThreadWorker<TOutputGraph, TMergingCostFunc, TUpdateAttributeFunc> worker;
+  worker.SetGraph( graph );
+  worker.SetMergingCostFunc( mergingCostFunc );
+  worker.SetRange(start, end);
+  worker.ComputeMergingCosts();
+
+}
+
+template<typename TOutputGraph, typename TMergingCostFunc, typename TUpdateAttributeFunc>
+void ResetMergeFlagsInRange (TOutputGraph * graph, TMergingCostFunc * mergingCostFunc, uint64_t start, uint64_t end)
+{
+
+  ThreadWorker<TOutputGraph, TMergingCostFunc, TUpdateAttributeFunc> worker;
+  worker.SetGraph( graph );
+  worker.SetMergingCostFunc( mergingCostFunc );
+  worker.SetRange(start, end);
+  worker.ResetMergeFlags();
+
+}
+
+template<typename TOutputGraph, typename TMergingCostFunc, typename TUpdateAttributeFunc>
+void FusionOfPairsInRange (TOutputGraph * graph, TUpdateAttributeFunc * updateAttributeFunc,
+    std::vector<std::pair<typename TOutputGraph::NodeType * ,typename TOutputGraph::NodeType * >> &pairsOfNodesToProcess,
+    uint64_t start, uint64_t end)
+{
+
+  ThreadWorker<TOutputGraph, TMergingCostFunc, TUpdateAttributeFunc> worker;
+  worker.SetGraph( graph );
+  worker.SetUpdateAttributeFunc( updateAttributeFunc );
+  worker.SetPairsOfNodesToProcess(pairsOfNodesToProcess);
+  worker.SetRange(start, end);
+  worker.FusionOfPairs();
+
+}
+
+template<typename TOutputGraph, typename TMergingCostFunc, typename TUpdateAttributeFunc>
+void ReconditioningInRange (TOutputGraph * graph, TMergingCostFunc * mergingCostFunc, uint64_t start, uint64_t end)
+{
+
+  ThreadWorker<TOutputGraph, TMergingCostFunc, TUpdateAttributeFunc> worker;
+  worker.SetGraph( graph );
+  worker.SetMergingCostFunc( mergingCostFunc );
+  worker.SetRange(start, end);
+  worker.Reconditioning();
+
+}
+
+template< typename TInputGraph, typename TOutputGraph, typename TMergingCostFunc, typename THeuristic, typename TUpdateAttributeFunc>
+bool
+GenericRegionMergingFilter<TInputGraph, TOutputGraph, TMergingCostFunc, THeuristic, TUpdateAttributeFunc>::DoOneIteration()
+{
+  // Output graph
+  auto outputGraph = this->GetOutput();
+
+  // Measure iteration total time
+  itk::TimeProbe titeration;  titeration.Start();
+
+  // Compute the merging costs for all the pairs of adjacent nodes.
+  itk::TimeProbe tcosts;  tcosts.Start();
+  ComputeMergingCosts();
+
+  tcosts.Stop(); timingsValues[1] += tcosts.GetTotal();
+  std::cout << std::setprecision(3) << tcosts.GetTotal() << "\t";
+
+  // Flag indicating if at least one merge has been done during the iteration.
+  bool merged = false;
+
+  itk::TimeProbe tmerge;  tmerge.Start();
+  itk::TimeProbe tmergePre;  tmergePre.Start();
+
+  // First part is not multithreaded, we just identify pairs of nodes to merge
+  // TODO: this 3 std::vector of pairs of nodes pointers seems not the best option !
+  //       pairsOfNodesToProcess_all has to be kept, but maybe the following vectors
+  //       might just be vectors or pointers:
+  //        * pairsOfNodesToProcess_parallel
+  //        * pairsOfNodesToProcess_sequential
+  typedef typename TInputGraph::NodeType NodeType;
+  typedef std::pair<NodeType * ,NodeType * > PairOfNodes;
+  std::vector<PairOfNodes> pairsOfNodesToProcess_parallel;
+  std::vector<PairOfNodes> pairsOfNodesToProcess_sequential;
+  std::vector<PairOfNodes> pairsOfNodesToProcess_all;
+
+  // Let's allocate the maximum number of pairs possible (ie 1+n/2)
+  const int64_t maxNbOfPairs = outputGraph->GetNumberOfNodes() / 2 + 1;
+  pairsOfNodesToProcess_parallel.reserve(maxNbOfPairs);
+  pairsOfNodesToProcess_sequential.reserve(maxNbOfPairs);
+  pairsOfNodesToProcess_all.reserve(maxNbOfPairs);
+
+  // Search the pairs to merge and fill the vector
+  for(auto nodeIt = outputGraph->Begin(); nodeIt != outputGraph->End(); nodeIt++)
+  {
+    // Heuristic to determine with which adjacent node this current node has to merge.
+    auto nodeIn = m_HeuristicFunc->GetBestAdjacentNode(&(*nodeIt));
+
+    // The heuristic must return true if no adjacent node has been found.
+    if(nodeIn != nullptr)
+    {
+      auto nodeOut = outputGraph->GetNodeAt(nodeIn->m_Edges.front().m_TargetId);
+
+//      // Useless?
+//      auto cost = nodeIn->m_Edges.front().m_Attributes.m_MergingCost;
+//      (void) cost;
+
+      // Both nodes must not have to be considered
+      nodeIn->m_Valid = false;
+      nodeOut->m_Valid = false;
+
+      PairOfNodes newPair;
+      newPair.first = nodeIn;
+      newPair.second = nodeOut;
+
+      // Keep trace of all pairs of nodes to merge
+      pairsOfNodesToProcess_all.push_back(newPair);
+
+      // TODO: push_back() seems to copy the input.
+      //       Maybe something smarted is required here (vector of pointers?).
+      if (nodeIn->m_ThreadSafeForMerge && nodeOut->m_ThreadSafeForMerge)
+        {
+          // Add the pair of nodes to process in parallel
+          pairsOfNodesToProcess_parallel.push_back(newPair);
+        }
+      else
+        {
+          // Add the pair of nodes to process in sequential
+          pairsOfNodesToProcess_sequential.push_back(newPair);
+        }
+
+      merged = true;
+
+    } // best adjacent node is not null
+
+  } // next node
+
+  // Store pre-merge processing time
+  tmergePre.Stop(); timingsValues[3] += tmergePre.GetTotal();
+
+  // Start parallel-merge processing time
+  itk::TimeProbe tmergeMulti; tmergeMulti.Start();
+
+  // Process the pairs of nodes in parallel
+  int64_t nbOfPairs = pairsOfNodesToProcess_parallel.size();
+  unsigned int nbOfThreads = this->GetNumberOfThreads();
+  int64_t chunkSize = nbOfPairs/nbOfThreads;
+  std::vector<std::thread> threadpoolMerge;
+  threadpoolMerge.reserve(nbOfThreads);
+  std::vector<std::pair<uint64_t,uint64_t>> ranges;
+  for(unsigned int i=0; i < nbOfThreads; i++ )
+    {
+    // Compute range
+    std::pair<uint64_t,uint64_t> range;
+    range.first = i*chunkSize;
+    if (i == nbOfThreads - 1 )
+      {
+      chunkSize += nbOfPairs % nbOfThreads;
+      }
+    range.second = range.first + chunkSize;
+    ranges.push_back(range);
+
+    // run thread
+    threadpoolMerge.push_back(
+        std::thread(FusionOfPairsInRange<TOutputGraph, TMergingCostFunc, TUpdateAttributeFunc>,
+            std::ref( outputGraph ),
+            std::ref( m_UpdateAttributeFunc ),
+            std::ref( pairsOfNodesToProcess_parallel ),
+            ranges[i].first,
+            ranges[i].second
+            )
+    );
+
+    } // next ProcessGraph() thread
+
+  // Barrier for threadpoolMerge
+  for (auto& t: threadpoolMerge) { t.join(); }
+
+  // Stop parallel-merge processing time
+  tmergeMulti.Stop(); timingsValues[4] += tmergeMulti.GetTotal();
+
+  itk::TimeProbe tmergeSeq; tmergeSeq.Start();
+
+  // merge non parallel
+  FusionOfPairsInRange<TOutputGraph, TMergingCostFunc, TUpdateAttributeFunc>(
+      outputGraph ,
+      m_UpdateAttributeFunc,
+      pairsOfNodesToProcess_sequential,
+      0,
+      pairsOfNodesToProcess_sequential.size()
+  );
+
+  tmergeSeq.Stop();
+
+  // Stop merge processing time
+  tmerge.Stop(); timingsValues[2] += tmerge.GetTotal();
+
+  std::cout << tmerge.GetTotal() << "\t"
+      << tmergePre.GetTotal() << "\t"
+      << tmergeMulti.GetTotal() << "\t"
+      << tmergeSeq.GetTotal() << "\t"
+      << this->GetOutput()->GetNumberOfNodes() << std::endl;
+
+  // Start remove() processing time
+  itk::TimeProbe tremove; tremove.Start();
+
+  outputGraph->RemoveNodes();
+
+  // Stop remove() processing time
+  tremove.Stop(); timingsValues[6] += tremove.GetTotal();
+
+  // Store iteration processing time
+  titeration.Stop();  timingsValues[0] += titeration.GetTotal();
+
+  if(outputGraph->GetNumberOfNodes() < 2)
+  {
+    return false;
+  }
+  return merged;
+
+}
+
+
+template< typename TInputGraph,
+		  typename TOutputGraph,
+		  typename TMergingCostFunc,
+		  typename THeuristic,
+		  typename TUpdateAttributeFunc>
 GenericRegionMergingFilter<TInputGraph, TOutputGraph, TMergingCostFunc, THeuristic, TUpdateAttributeFunc>
 ::GenericRegionMergingFilter()
 : m_MaxNumberOfIterations(75), m_AppliedNumberOfIterations(0), m_MergingOver(false), m_MergingCostFunc(nullptr),
 m_HeuristicFunc(nullptr), m_UpdateAttributeFunc(nullptr)
 {
+	std::cout << "Create Filter Object" << std::endl;
 }
 
-template< typename TInputGraph, 
-          typename TOutputGraph, 
-          typename TMergingCostFunc, 
-          typename THeuristic, 
-          typename TUpdateAttributeFunc>
+template< typename TInputGraph,
+		  typename TOutputGraph,
+		  typename TMergingCostFunc,
+		  typename THeuristic,
+		  typename TUpdateAttributeFunc>
 GenericRegionMergingFilter<TInputGraph, TOutputGraph, TMergingCostFunc, THeuristic, TUpdateAttributeFunc>
 ::~GenericRegionMergingFilter()
 {
-    if(m_MergingCostFunc != nullptr){
-        delete m_MergingCostFunc;
-    }
+	if(m_MergingCostFunc != nullptr){
+		delete m_MergingCostFunc;
+	}
 
-    if(m_HeuristicFunc != nullptr){
-        delete m_HeuristicFunc;
-    }
+	if(m_HeuristicFunc != nullptr){
+		delete m_HeuristicFunc;
+	}
 
-    if(m_UpdateAttributeFunc != nullptr){
-        delete m_UpdateAttributeFunc;
-    }
+	if(m_UpdateAttributeFunc != nullptr){
+		delete m_UpdateAttributeFunc;
+	}
 }
 
 
 template< typename TInputGraph,
-          typename TOutputGraph,
-          typename TMergingCostFunc,
-          typename THeuristic,
-          typename TUpdateAttributeFunc>
+		  typename TOutputGraph,
+		  typename TMergingCostFunc,
+		  typename THeuristic,
+		  typename TUpdateAttributeFunc>
 void
 GenericRegionMergingFilter<TInputGraph, TOutputGraph, TMergingCostFunc, THeuristic, TUpdateAttributeFunc>
 ::PrintSelf(std::ostream & os, itk::Indent indent) const
@@ -55,210 +492,175 @@ GenericRegionMergingFilter<TInputGraph, TOutputGraph, TMergingCostFunc, THeurist
 }
 
 template< typename TInputGraph,
-          typename TOutputGraph,
-          typename TMergingCostFunc,
-          typename THeuristic,
-          typename TUpdateAttributeFunc>
+		  typename TOutputGraph,
+		  typename TMergingCostFunc,
+		  typename THeuristic,
+		  typename TUpdateAttributeFunc>
 void
 GenericRegionMergingFilter<TInputGraph, TOutputGraph, TMergingCostFunc, THeuristic, TUpdateAttributeFunc>::
 GenerateData()
 {
-	//Check validity
-	CheckValidity();
+	std::cout << "Generate Data" << std::endl;
+	auto outputGraph = this->GetOutputByMove();
 
-    auto outputGraph = this->GetOutputByMove();
+	//Set the graph for the heuristic
+	this->GetHeuristicFunc()->SetGraph(outputGraph);
 
-    //Set the graph for the heuristic
-    this->GetHeuristicFunc()->SetGraph(outputGraph);
+	// Reconditionning of the graph
+	itk::TimeProbe recon_probe; recon_probe.Start();
 
-    // Reconditionning of the graph
-    for(auto nodeIt = outputGraph->Begin(); nodeIt != outputGraph->End(); nodeIt++)
+  int64_t nbOfNodes = outputGraph->GetNumberOfNodes();
+  unsigned int nbOfThreads = this->GetNumberOfThreads();
+  int64_t chunkSize = nbOfNodes/nbOfThreads;
+
+  std::vector<std::thread> threadpoolReconditioning;
+  threadpoolReconditioning.reserve(nbOfThreads);
+  std::vector<std::pair<uint64_t,uint64_t>> ranges;
+  for(unsigned int i=0; i < nbOfThreads; i++ )
     {
-        nodeIt->m_HasToBeRemoved = false;
-        nodeIt->m_Valid = true;
-        nodeIt->m_Attributes.m_HasPreviouslyMerged = true;
-        for(auto& edg : nodeIt->m_Edges)
-        {
-            edg.m_Attributes.m_MergingCost = m_MergingCostFunc->GetMax();
-            edg.m_Attributes.m_CostUpdated = false;
-        }
-    }
+    // Compute range
+    std::pair<uint64_t,uint64_t> range;
+    range.first = i*chunkSize;
+    if (i == nbOfThreads - 1 )
+      {
+      chunkSize += nbOfNodes % nbOfThreads;
+      }
+    range.second = range.first + chunkSize;
+    ranges.push_back(range);
 
-    for(uint32_t i = 0; i < m_MaxNumberOfIterations; i++)
-    {
-        std::cout << "iteration " << i+1 << "/" << m_MaxNumberOfIterations <<  std::endl;
-        std::cout <<"Number of nodes = " << this->GetOutput()->GetNumberOfNodes() << std::endl;
-        if(!DoOneIteration())
-        {
-            m_MergingOver = true;
-            break;
-        }
-    }
+    // run thread
+    threadpoolReconditioning.push_back(
+        std::thread(ReconditioningInRange<TOutputGraph, TMergingCostFunc, TUpdateAttributeFunc>,
+            std::ref( outputGraph ),
+            std::ref( m_MergingCostFunc ),
+            ranges[i].first,
+            ranges[i].second)
+    );
+
+    } // next ProcessGraph() thread
+
+  // Barrier for threadpoolReconditioning
+  for (auto& t: threadpoolReconditioning) { t.join(); }
+
+	recon_probe.Stop();
+	std::cout << "Reconditioning : " << recon_probe.GetTotal() << std::endl;
+
+	// setup timings
+	timingsValues.push_back(0.0f); timingsLabels.push_back("iterations");    // 0
+  timingsValues.push_back(0.0f); timingsLabels.push_back("costs");         // 1
+  timingsValues.push_back(0.0f); timingsLabels.push_back("merging");       // 2
+  timingsValues.push_back(0.0f); timingsLabels.push_back("merging.pre");   // 3
+  timingsValues.push_back(0.0f); timingsLabels.push_back("merging.multi"); // 4
+  timingsValues.push_back(0.0f); timingsLabels.push_back("merging.post");  // 5
+  timingsValues.push_back(0.0f); timingsLabels.push_back("remove");        // 6
+
+	std::cout << "Iter.\t"
+	    << "Costs\t"
+      << "Merge\t"
+      << "Merge(pre)\t"
+      << "Merge(//)\t" // parallel
+      << "Merge(--)\t" // sequential
+	    << "nodes\t" << std::endl;
+
+	uint64_t initialNbOfNodes = outputGraph->GetNumberOfNodes();
+	this->UpdateProgress(.0f);
+	for(uint32_t i = 0; i < m_MaxNumberOfIterations; i++)
+	{
+		std::cout << std::setprecision(5) << i+1 << "\t";
+		if(!DoOneIteration())
+		{
+			m_MergingOver = true;
+			break;
+		}
+
+		// TODO: it should be possible to estimate the progress
+		// with a model (a,b) like n(k)=exp(-k.a)+b where n(k) is the number
+		// of nodes at each iteration k
+//		float progress = ...
+//		this->UpdateProgress(progress);
+
+	} // next iteration
+	this->UpdateProgress(1.0f);
+	std::cout << std::endl;
+
+	// Display timings
+	std::cout << " Overall processing time : " << std::endl;
+	std::cout << "NbThreads";
+  for (unsigned int i = 0 ; i < timingsLabels.size() ; i++)
+    std::cout << "\t" <<  timingsLabels[i]  ;
+  std::cout << std::endl;
+  std::cout << this->GetNumberOfThreads();
+  for (unsigned int i = 0 ; i < timingsLabels.size() ; i++)
+    std::cout << "\t" << std::setprecision(5) << timingsValues[i];
+  std::cout << std::endl;
+
 }
 
 
-template< typename TInputGraph, typename TOutputGraph, typename TMergingCostFunc, typename THeuristic, typename TUpdateAttributeFunc>
-bool 
-GenericRegionMergingFilter<TInputGraph, TOutputGraph, TMergingCostFunc, THeuristic, TUpdateAttributeFunc>::DoOneIteration()
-{
-    // Compute the merging costs for all the pairs of adjacent nodes.
-    ComputeMergingCosts();
 
-    auto outputGraph = this->GetOutput();
-    
-    // Flag indicating if at least one merge has been done during the iteration.
-    bool merged = false;
-
-    for(auto nodeIt = outputGraph->Begin(); nodeIt != outputGraph->End(); nodeIt++)
-    {
-        // Heuristic to determine with which adjacent node this current node has to merge.
-        auto nodeIn = m_HeuristicFunc->GetBestAdjacentNode(&(*nodeIt));
-
-        // The heuristic must return true if no adjacent node has been found.
-        if(nodeIn != nullptr)
-        {
-            auto nodeOut = outputGraph->GetNodeAt(nodeIn->m_Edges.front().m_TargetId);
-
-            auto cost = nodeIn->m_Edges.front().m_Attributes.m_MergingCost;
-
-            Merge(nodeIn, nodeOut);
-
-            merged = true;
-
-        }
-
-    }
-
-    outputGraph->RemoveNodes();
-
-    if(outputGraph->GetNumberOfNodes() < 2)
-    {
-        return false;
-    }
-
-    return merged;
-
-}
-
-template< typename TInputGraph, 
-          typename TOutputGraph, 
-          typename TMergingCostFunc, 
-          typename THeuristic,
-          typename TUpdateAttributeFunc>
-void
-GenericRegionMergingFilter<TInputGraph, TOutputGraph, TMergingCostFunc, THeuristic, TUpdateAttributeFunc>
-::Merge(NodeType* nodeIn, NodeType * nodeOut)
-{
-    m_UpdateAttributeFunc->UpdateAttributes(nodeIn, nodeOut);
-    auto outputGraph = this->GetOutput();
-    outputGraph->Merge(nodeIn, nodeOut);
-}
-
+/*
+ * Fully parallel
+ */
 template< typename TInputGraph, typename TOutputGraph, typename TMergingCostFunc, typename THeuristic, typename TUpdateAttributeFunc >
 void
 GenericRegionMergingFilter<TInputGraph, TOutputGraph, TMergingCostFunc, THeuristic, TUpdateAttributeFunc>::ComputeMergingCosts()
 {
-    std::cout << "Compute Merging cost" << std::endl;
-    // Retrieve the output graph.
 
-    auto outputGraph = this->GetOutput();
+  // Retrieve the output graph.
+  auto outputGraph = this->GetOutput();
 
-    MergingCostValueType minCost;
-    // Fix : uninitialized variable
-    uint64_t minNodeId = outputGraph->GetNumberOfNodes()+1, idx, minIdx;
+  int64_t nbOfNodes = outputGraph->GetNumberOfNodes();
+  unsigned int nbOfThreads = this->GetNumberOfThreads();
+  int64_t chunkSize = nbOfNodes/nbOfThreads;
 
-    std::cout << "updating attribute cost updated ...";
-    // The nodes must have a boolean attribute called m_CostUpdated.
-    for(auto nodeIt =outputGraph->Begin(); nodeIt != outputGraph->End(); nodeIt++)
+  std::vector<std::thread> threadpoolComputeMergingCosts, threadpoolReset;
+  threadpoolComputeMergingCosts.reserve(nbOfThreads);
+  threadpoolReset.reserve(nbOfThreads);
+  std::vector<std::pair<uint64_t,uint64_t>> ranges;
+  for(unsigned int i=0; i < nbOfThreads; i++ )
     {
-        for(auto edgeIt = nodeIt->m_Edges.begin(); edgeIt != nodeIt->m_Edges.end(); edgeIt++)
-        {
-            edgeIt->m_Attributes.m_CostUpdated = false;
-        }
-    }
-    std::cout << "OK ." << std::endl;
+    // Compute range
+    std::pair<uint64_t,uint64_t> range;
+    range.first = i*chunkSize;
+    if (i == nbOfThreads - 1 )
+      {
+      chunkSize += nbOfNodes % nbOfThreads;
+      }
+    range.second = range.first + chunkSize;
+    ranges.push_back(range);
 
+    // run thread
+    threadpoolComputeMergingCosts.push_back(
+        std::thread(ComputeMergingCostsInRange<TOutputGraph, TMergingCostFunc, TUpdateAttributeFunc>,
+            std::ref( outputGraph ),
+            std::ref( m_MergingCostFunc ),
+            ranges[i].first,
+            ranges[i].second)
+    );
 
-    std::cout << "Number of nodes : " << std::endl;
+    } // next ProcessGraph() thread
 
-    // Loop over the nodes
-    for(auto nodeIt = outputGraph->Begin(); nodeIt != outputGraph->End(); nodeIt++)
+  // Barrier for threadpoolProcess
+  for (auto& t: threadpoolComputeMergingCosts) { t.join(); }
+
+  // Reset
+  for(unsigned int i=0; i < nbOfThreads; i++ )
     {
 
-        if(m_MergingCostFunc->ComputeMergingCostsForThisNode(&(*nodeIt))
-	 && nodeIt->m_Edges.size() > 0)
-        {
+    // run thread
+    threadpoolReset.push_back(
+        std::thread(ResetMergeFlagsInRange<TOutputGraph, TMergingCostFunc, TUpdateAttributeFunc>,
+            std::ref( outputGraph ),
+            std::ref( m_MergingCostFunc ),
+            ranges[i].first,
+            ranges[i].second)
+    );
 
-            // The merging cost function must give the maximum value of the merging cost.
-            minCost = MergingCostFunctionType::Max();
-            idx = 0;
-            minIdx = 0;
-            nodeIt->m_HasToBeRemoved = false;
-            nodeIt->m_Valid = true;
+    } // next ResetGraph() thread
 
-            // Loop over the edges
-            for(auto edgeIt = nodeIt->m_Edges.begin(); edgeIt != nodeIt->m_Edges.end(); edgeIt++)
-            {
-                // Retrieve the adjacent node.
+  // Barrier for threadpoolReset
+  for (auto& t: threadpoolReset) { t.join(); }
 
-                auto adjNode = outputGraph->GetNodeAt(edgeIt->m_TargetId);
-
-                if(m_MergingCostFunc->ComputeMergingCostsForThisAdjNode(adjNode))
-                {
-
-                    // If the cost is not updated and if one of the adjacent nodes
-                    // has merged at the previous iteration then we must compute the
-                    // merging cost.
-                    if(!(edgeIt->m_Attributes.m_CostUpdated) && 
-                        (nodeIt->m_Attributes.m_HasPreviouslyMerged || 
-                           adjNode->m_Attributes.m_HasPreviouslyMerged))
-                    {
-                        edgeIt->m_Attributes.m_MergingCost = m_MergingCostFunc->ComputeMergingCost(&(*nodeIt), adjNode);
-                        auto adjNodeToCurr = adjNode->FindEdge(nodeIt->m_Id);
-                        adjNodeToCurr->m_Attributes.m_MergingCost = edgeIt->m_Attributes.m_MergingCost;
-                        edgeIt->m_Attributes.m_CostUpdated = true;
-                        adjNodeToCurr->m_Attributes.m_CostUpdated = true;
-                    }
-
-
-                    // If the current cost is minimum than we record it.
-                    if(edgeIt->m_Attributes.m_MergingCost < minCost)
-                    {
-                        minCost = edgeIt->m_Attributes.m_MergingCost;
-                        minNodeId = adjNode->GetFirstPixelCoords();
-                        minIdx = idx;
-                    }
-
-                    // In case of equality, we keep the adjacent node with the lower starting
-                    // coordinates.
-                    else if(minCost == edgeIt->m_Attributes.m_MergingCost)
-                    {
-                        if(adjNode->GetFirstPixelCoords() < minNodeId)
-                        {
-                            minNodeId = adjNode->GetFirstPixelCoords();
-                            minIdx = idx;
-                        }
-                    }
-
-                } // end if(MergingCostFunctionType::ComputeMergingCostsForThisAdjNode(adjNode))
-
-                idx++;
-
-            } // end loop over the edges.
-
-            // Finally we move the adjacent node with the lower merging cost
-            // at the first position in the list of adjacent nodes.
-            std::swap(nodeIt->m_Edges[0], nodeIt->m_Edges[minIdx]);
-
-        } // end if(MergingCostFunctionType::ComputeMergingCostsForThisNode(&(*nodeIt)))
-
-    } // end for loop over the nodes
-
-    // Reset the merge flag for all the nodes.
-    for(auto nodeIt =outputGraph->Begin(); nodeIt != outputGraph->End(); nodeIt++)
-    {
-        nodeIt->m_Attributes.m_HasPreviouslyMerged = false;
-    }
 
 }
 
@@ -266,10 +668,10 @@ template< typename TInputGraph, typename TOutputGraph, typename TMergingCostFunc
 void
 GenericRegionMergingFilter<TInputGraph, TOutputGraph, TMergingCostFunc, THeuristic, TUpdateAttributeFunc>::CheckValidity()
 {
-    if(m_MergingCostFunc == nullptr || m_HeuristicFunc == nullptr || m_UpdateAttributeFunc == nullptr)
-    {
-        std::cerr << "GenericRegionMergingFilter not initialized like it should..." << std::endl;
-    }
+	if(m_MergingCostFunc == nullptr || m_HeuristicFunc == nullptr || m_UpdateAttributeFunc == nullptr)
+	{
+		std::cerr << "GenericRegionMergingFilter not initialized like it should..." << std::endl;
+	}
 }
 } // end of namespace obia
 } // end of namespace otb

--- a/include/otbObiaGraph.h
+++ b/include/otbObiaGraph.h
@@ -137,7 +137,9 @@ struct Node
          m_HasToBeRemoved(other.m_HasToBeRemoved), m_Valid(other.m_Valid),
          m_Id(other.m_Id), m_BoundingBox(other.m_BoundingBox),
          m_Contour(other.m_Contour), m_Edges(other.m_Edges),
-         m_Attributes(other.m_Attributes)
+         m_Attributes(other.m_Attributes), m_ThreadSafe(other.m_ThreadSafe),
+         m_ThreadSafeForMerge(other.m_ThreadSafeForMerge)
+
     {}
 
     /**\brief Returns the vectorized coordinates (x,y) of the first pixel composing this node. */
@@ -196,6 +198,10 @@ struct Node
 
     /**\brief Specific attributes related to the node*/
     NodeAttributeType m_Attributes;
+
+    /**\brief Thread safe properties of the node*/
+    bool m_ThreadSafe:1;
+    bool m_ThreadSafeForMerge:1;
 
     /**\brief Debug */
     EdgeIteratorType Begin(){return m_Edges.begin();}
@@ -288,7 +294,7 @@ public:
     /** \brief This methods removes the expired nodes from the graph, i.e
         those whose m_HasToBeRemoved is true.
     */
-    void RemoveNodes(bool merge =true);
+    void RemoveNodes();
 
     /** \brief This methods returns the quantity of memory in bytes to store this graph */
     uint64_t GetMemorySize() const;
@@ -328,6 +334,11 @@ public:
       NodeListType().swap(m_Nodes);
     }
 
+    /**\brief Merge edge between 2 nodes by updating contour, boundary, edges, etc ...
+	 * \param: Node in
+	 * \param: Node Out*/
+	void MergeEdge(NodeType* nodeIn, NodeType* nodeOut);
+
 protected:
 
     Graph(){}
@@ -356,13 +367,6 @@ protected:
     double m_OriginY;
     std::string m_ProjectionRef;
 
-
-private:
-
-    /**\brief Merge edge between 2 nodes by updating contour, boundary, edges, etc ...
-     * \param: Node in
-     * \param: Node Out*/
-    void MergeEdge(NodeType* nodeIn, NodeType* nodeOut);
 };
 
 } // end of namespace obia

--- a/include/otbObiaGraph.h
+++ b/include/otbObiaGraph.h
@@ -285,6 +285,10 @@ public:
     /**\brief This method applies a lambda function on each node of the graph. */
     template< typename LambdaFunctionType >
     void ApplyForEachNode(LambdaFunctionType f);
+    template< typename LambdaFunctionType >
+    void ApplyForEachNode(const uint64_t rangeStart, const uint64_t rangeEnd, LambdaFunctionType f);
+
+    void MergePairOfNodes(NodeType* nodeIn, NodeType* nodeOut);
 
     /**\brief This method merges two adjacent nodes: nodeOut merges into nodeIn
      * @param: Node in (node which will be updated after merge)
@@ -293,8 +297,9 @@ public:
 
     /** \brief This methods removes the expired nodes from the graph, i.e
         those whose m_HasToBeRemoved is true.
+        @param: a boolean telling if nodes/edges IDs have to be updated
     */
-    void RemoveNodes();
+    std::vector<uint32_t> RemoveNodes(bool update = true);
 
     /** \brief This methods returns the quantity of memory in bytes to store this graph */
     uint64_t GetMemorySize() const;
@@ -310,7 +315,7 @@ public:
      * \param : Other graph*/
     void InsertAtEnd(const Pointer& other)
     {
-       	m_Nodes.insert(m_Nodes.end(), other->Begin(), other->End());	
+        m_Nodes.insert(m_Nodes.end(), other->Begin(), other->End());
     }
 
     /**\brief Move the graph to the input pointer
@@ -335,9 +340,9 @@ public:
     }
 
     /**\brief Merge edge between 2 nodes by updating contour, boundary, edges, etc ...
-	 * \param: Node in
-	 * \param: Node Out*/
-	void MergeEdge(NodeType* nodeIn, NodeType* nodeOut);
+     * \param: Node in
+     * \param: Node Out*/
+    void MergeEdge(NodeType* nodeIn, NodeType* nodeOut);
 
 protected:
 

--- a/include/otbObiaGraph.txx
+++ b/include/otbObiaGraph.txx
@@ -132,27 +132,30 @@ Graph<TNode>::InitStartingNode(NodeType* node, const IdType id)
     node->m_Contour.SetStartingCoords(id);
     node->m_Contour.FirstInit();
 
-    // Initialisation of the edges
-    auto neighbors = otb::obia::SpatialTools::FourConnectivity(id, m_ImageWidth, m_ImageHeight);
-
-    uint32_t numEdges = 0;
-    for(unsigned short n = 0; n < 4; n++){ if(neighbors[n] > -1){ numEdges++; } }
-    node->m_Edges.reserve(numEdges);
-
-    for(unsigned short n = 0; n < 4; n++)
-    {
-        if(neighbors[n] > -1)
-        {
-            // Add an edge to the current node targeting the adjacent node
-            auto newEdge = node->AddEdge();
-
-            // Add the target
-            newEdge->m_TargetId = neighbors[n];
-
-            // Initialisation of the boundary
-            newEdge->m_Boundary = 1;
-        }
-    }
+    // We don't fo this here anymore.
+    // Now we use nodata to init properly the edges in the imageToGraph
+    
+//    // Initialisation of the edges
+//    auto neighbors = otb::obia::SpatialTools::FourConnectivity(id, m_ImageWidth, m_ImageHeight);
+//
+//    uint32_t numEdges = 0;
+//    for(unsigned short n = 0; n < 4; n++){ if(neighbors[n] > -1){ numEdges++; } }
+//    node->m_Edges.reserve(numEdges);
+//
+//    for(unsigned short n = 0; n < 4; n++)
+//    {
+//        if(neighbors[n] > -1)
+//        {
+//            // Add an edge to the current node targeting the adjacent node
+//            auto newEdge = node->AddEdge();
+//
+//            // Add the target
+//            newEdge->m_TargetId = neighbors[n];
+//
+//            // Initialisation of the boundary
+//            newEdge->m_Boundary = 1;
+//        }
+//    }
 }
 
 template< typename TNode >
@@ -206,159 +209,168 @@ void Graph<TNode>::ApplyForEachNode(LambdaFunctionType f)
 }
 
 template< typename TNode >
+template< typename LambdaFunctionType >
+void Graph<TNode>::ApplyForEachNode(const uint64_t rangeStart, const uint64_t rangeEnd, LambdaFunctionType f)
+{
+    std::for_each(m_Nodes.begin()+rangeStart, m_Nodes.begin()+rangeEnd, f);
+}
+
+template< typename TNode >
 void
 Graph<TNode>::MergeEdge(NodeType* nodeIn, NodeType* nodeOut)
 {
-	double startCoords = nodeIn->GetFirstPixelCoords();
-	double startCoords2 = nodeOut->GetFirstPixelCoords();
 
-	// Explore the edges of nodeOut
-    for(auto edgeIt = nodeOut->m_Edges.begin(); edgeIt != nodeOut->m_Edges.end(); edgeIt++)
+  // Explore the edges of nodeOut
+  for(auto& edgeIt : nodeOut->m_Edges)
     {
-        // Local variable to record the boundary length of nodeOut with its
-        // adjacent node.
-        uint32_t boundary;
-        
-        // Retrieve the adjacent node of nodeOut -> adjNodeOut
-        auto adjNodeOut = GetNodeAt(edgeIt->m_TargetId);
+    // Local variable to record the boundary length of nodeOut with its
+    // adjacent node.
+    uint32_t boundary;
 
-        // Find the edge from adjNodeOut to nodeOut
-        auto edgAdjToOut = adjNodeOut->FindEdge(nodeOut->m_Id);
+    // Retrieve the adjacent node of nodeOut -> adjNodeOut
+    auto adjNodeOut = GetNodeAt(edgeIt.m_TargetId);
 
-        // If this edge is the first edge of adjNodeOut then adjNodeOut is not valid
-        // anymore for merging with one of its adjacent node during a segmentation process.
-        // This is not so generic since some obia processes won't need that but it is a price
-        // to pay to factorize and shorten a bit the code.
-        if(edgAdjToOut == adjNodeOut->m_Edges.begin())
+    // Find the edge from adjNodeOut to nodeOut
+    auto edgAdjToOut = adjNodeOut->FindEdge(nodeOut->m_Id);
+
+    // If this edge is the first edge of adjNodeOut then adjNodeOut is not valid
+    // anymore for merging with one of its adjacent node during a segmentation process.
+    // This is not so generic since some obia processes won't need that but it is a price
+    // to pay to factorize and shorten a bit the code.
+    if(edgAdjToOut == adjNodeOut->m_Edges.begin())
+      {
+      adjNodeOut->m_Valid = false;
+      }
+
+    // Record the boundary length between adjNodeOut and nodeOut
+    boundary = edgAdjToOut->m_Boundary;
+
+    // The edge adjNodeOut -> nodeOut can be safely removed
+    adjNodeOut->m_Edges.erase(edgAdjToOut);
+
+    // Edges have to be added or updated if adjNodeOut is not nodeIn
+    if(adjNodeOut != nodeIn)
+      {
+      // Try to find if there is an edge between adjNodeOut and nodeIn
+      auto edgAdjToIn = adjNodeOut->FindEdge(nodeIn->m_Id);
+
+      if(edgAdjToIn == adjNodeOut->m_Edges.end())
         {
-            adjNodeOut->m_Valid = false;
+        // If the edge does not exist, it has to be created
+
+        // AdjNodeOut -> nodeIn
+        auto adjOutToIn = adjNodeOut->AddEdge();
+        adjOutToIn->m_TargetId = nodeIn->m_Id;
+        adjOutToIn->m_Boundary = boundary;
+
+        // nodeIn -> AdjNodeOut
+        auto inToAdjOut = nodeIn->AddEdge();
+        inToAdjOut->m_TargetId = adjNodeOut->m_Id;
+        inToAdjOut->m_Boundary = boundary;
+
+        } // end if(edgAdjToIn == adjNodeOut->m_Edges.end())
+      else
+        {
+        // the edges exist, the boundary attribute has to be updated
+
+        // Increment AdjNodeOut -> nodeIn
+        edgAdjToIn->m_Boundary += boundary;
+
+        // Increment nodeIn -> AdjNodeOut
+        auto edgInToAdj = nodeIn->FindEdge(adjNodeOut->m_Id);
+        edgInToAdj->m_Boundary += boundary;
         }
 
-        // Record the boundary length between adjNodeOut and nodeOut
-        boundary = edgAdjToOut->m_Boundary;
-
-        // The edge adjNodeOut -> nodeOut can be safely removed
-        adjNodeOut->m_Edges.erase(edgAdjToOut);
-
-        // Edges have to be added or updated if adjNodeOut is not nodeIn
-        if(adjNodeOut != nodeIn)
-        {
-            // Try to find if there is an edge between adjNodeOut and nodeIn
-            auto edgAdjToIn = adjNodeOut->FindEdge(nodeIn->m_Id);
-
-            if(edgAdjToIn == adjNodeOut->m_Edges.end())
-            {
-                // If the edge does not exist, it has to be created
-
-                // AdjNodeOut -> nodeIn
-                auto adjOutToIn = adjNodeOut->AddEdge();
-                adjOutToIn->m_TargetId = nodeIn->m_Id;
-                adjOutToIn->m_Boundary = boundary;
-
-                // nodeIn -> AdjNodeOut
-                auto inToAdjOut = nodeIn->AddEdge();
-                inToAdjOut->m_TargetId = adjNodeOut->m_Id;
-                inToAdjOut->m_Boundary = boundary;
-
-            } // end if(edgAdjToIn == adjNodeOut->m_Edges.end())
-            else
-            {
-                // the edges exist, the boundary attribute has to be updated
-
-                // Increment AdjNodeOut -> nodeIn
-                edgAdjToIn->m_Boundary += boundary;
-
-                // Increment nodeIn -> AdjNodeOut
-                auto edgInToAdj = nodeIn->FindEdge(adjNodeOut->m_Id);
-                edgInToAdj->m_Boundary += boundary;
-            }
-
-        } // end if(adjNodeOut != nodeIn)
+      } // end if(adjNodeOut != nodeIn)
 
     } // end for(auto edgeIt = nodeOut->m_Edges.begin(); edgeIt != nodeOut->m_Edges.end(); edgeIt++)
 
-    // All the edges of nodeOut can be safely removes
-    typename NodeType::EdgeListType().swap(nodeOut->m_Edges);
+  // All the edges of nodeOut can be safely removes
+  typename NodeType::EdgeListType().swap(nodeOut->m_Edges);
+}
+
+template< typename TNode >
+void
+Graph<TNode>::MergePairOfNodes(NodeType* nodeIn, NodeType* nodeOut)
+{
+  // Fusion of the bounding box
+  SpatialTools::MergeBoundingBox(nodeIn->m_BoundingBox, nodeOut->m_BoundingBox);
+
+  // Fusion of the contour
+  nodeIn->m_Contour.MergeWith(nodeOut->m_Contour, m_ImageWidth, m_ImageHeight);
+
+  // Fusion of the edges
+  MergeEdge(nodeIn, nodeOut);
+
+  // nodeOut has to be removed, so we mark it as it
+  nodeOut->m_HasToBeRemoved = true;
 }
 
 template< typename TNode >
 void 
 Graph<TNode>::Merge(NodeType* nodeIn, NodeType* nodeOut)
 {
-    // Fusion of the bounding box
-    SpatialTools::MergeBoundingBox(nodeIn->m_BoundingBox, nodeOut->m_BoundingBox);
+  // Merge the pair of nodes
+  MergePairOfNodes(nodeIn, nodeOut);
 
-    // Fusion of the contour
-    nodeIn->m_Contour.MergeWith(nodeOut->m_Contour, m_ImageWidth, m_ImageHeight);
-
-    // Fusion of the edges
-    MergeEdge(nodeIn, nodeOut);
-
-    // nodeOut has to be removed, so we mark it as it
-    nodeOut->m_HasToBeRemoved = true;
-
-    // Both nodes must not have to be considered
-    nodeIn->m_Valid = false;
-    nodeOut->m_Valid = false;
+  // Both nodes must not have to be considered
+  nodeIn->m_Valid = false;
+  nodeOut->m_Valid = false;
 }
 
 template< typename TNode >
-void 
-Graph<TNode>::RemoveNodes(bool merge /*=true*/)
+std::vector<uint32_t> 
+Graph<TNode>::RemoveNodes(bool update)
 {
-    // To keep nodes aligned in memory, we avoid using vector of pointers
-    // but directly vector of nodes. However this complicates the removal
-    // operation since the ids of the nodes has to be updated.
-    // Space complexity: O(Nt + Et) where Nt is the total number of nodes and Et the total number of edges
-    // Time complexity: O(Nt * E) where Nt is the total number of nodes and E the average number of edges per node.
+  // To keep nodes aligned in memory, we avoid using vector of pointers
+  // but directly vector of nodes. However this complicates the removal
+  // operation since the ids of the nodes has to be updated.
+  // Space complexity: O(Nt + Et) where Nt is the total number of nodes and Et the total number of edges
+  // Time complexity: O(Nt * E) where Nt is the total number of nodes and E the average number of edges per node.
 
-    // Count the number of merged nodes at each position
-    // Linear in time wrt to the number of nodes
-    std::vector<uint32_t> numMergedNodes(m_Nodes.size(), 0);
-    uint64_t idx = 0;
-    uint32_t numMerged = 0;
+  // Count the number of merged nodes at each position
+  // Linear in time wrt to the number of nodes
+  std::vector<uint32_t> numMergedNodes(m_Nodes.size(), 0);
+  uint64_t idx = 0;
+  uint32_t numMerged = 0;
 
-    
-     auto lambdaNumMerges = [&numMergedNodes, &idx, &numMerged](const NodeType& node){
+  auto lambdaNumMerges = [&numMergedNodes, &idx, &numMerged](const NodeType& node){
 
-       if(node.m_HasToBeRemoved)
-	{
-	    numMerged++;
-	}
-
-	numMergedNodes[idx] = numMerged;
-	idx++;
-    };
-
-ApplyForEachNode(lambdaNumMerges);
-   
-
-
-    // Remove the nodes: Linear in time wrt to the number of nodes
-    auto eraseIt = std::remove_if(m_Nodes.begin(), m_Nodes.end(), [](NodeType& node){
-        return node.m_HasToBeRemoved == true;
-    });
-
-    m_Nodes.erase(eraseIt, m_Nodes.end());
-
-    // m_Nodes.shrink_to_fit();
-
-    // shrink_to_fit all edges container
-    for (auto it = m_Nodes.begin(); it != m_Nodes.end();++it)
+    if(node.m_HasToBeRemoved)
       {
-      it->m_Edges.shrink_to_fit();
+      numMerged++;
       }
+
+    numMergedNodes[idx] = numMerged;
+    idx++;
+  };
+
+  ApplyForEachNode(lambdaNumMerges);
+
+  // Remove the nodes: Linear in time wrt to the number of nodes
+  auto eraseIt = std::remove_if(m_Nodes.begin(), m_Nodes.end(), [](NodeType& node){
+    return node.m_HasToBeRemoved == true;
+  });
+
+  m_Nodes.erase(eraseIt, m_Nodes.end());
+
+  // We might want do this in parallel instead
+  if (update)
+    {
     auto lambdaDecrementIdEdge = [&numMergedNodes](EdgeType& edge){
-        edge.m_TargetId = edge.m_TargetId - numMergedNodes[edge.m_TargetId];
+      edge.m_TargetId = edge.m_TargetId - numMergedNodes[edge.m_TargetId];
     };
 
     auto lambdaDecrementIdNode = [&numMergedNodes, &lambdaDecrementIdEdge]( NodeType& node ){
-        // Update the node's id
-        node.m_Id = node.m_Id - numMergedNodes[node.m_Id];
-        node.ApplyForEachEdge(lambdaDecrementIdEdge);
+      // Update the node's id
+      node.m_Id = node.m_Id - numMergedNodes[node.m_Id];
+      node.ApplyForEachEdge(lambdaDecrementIdEdge);
     };
 
     ApplyForEachNode(lambdaDecrementIdNode);
+    }   
+  return numMergedNodes;
+
 }
 
 template< typename TNode >

--- a/include/otbObiaImageToBaatzGraphFilter.h
+++ b/include/otbObiaImageToBaatzGraphFilter.h
@@ -21,13 +21,10 @@ struct BaatzEdgeAttribute : GraphAttribute
     // Merging cost
     float m_MergingCost;
 
-    // Flag indicating if the merging cost has to be recomputed.
-    bool m_CostUpdated;
-
     BaatzEdgeAttribute(){}
 
     BaatzEdgeAttribute(const BaatzEdgeAttribute& other) 
-        : m_MergingCost(other.m_MergingCost), m_CostUpdated(other.m_CostUpdated)
+        : m_MergingCost(other.m_MergingCost)
     {}
 
     virtual uint64_t GetMemorySize() const;

--- a/include/otbObiaLSImageToGraphScheduler.txx
+++ b/include/otbObiaLSImageToGraphScheduler.txx
@@ -443,12 +443,12 @@ LSImageToGraphScheduler<TInputImage, TOutputGraph>
 	using GraphToLabelImageFilterType = otb::obia::GraphToLabelImageFilter<TOutputGraph, LabelImageType>;
 	using WriterType = otb::ImageFileWriter< LabelImageType>;
 
-	/** FOR COLOR IMAGE
+	// FOR COLOR IMAGE
 	using RGBPixelType = itk::RGBPixel<unsigned char>;
 	using RGBImageType = otb::Image<RGBPixelType, 2>;
 	using LabelToRGBFilterType = itk::LabelToRGBImageFilter<LabelImageType, RGBImageType>;
 	using RGBWriterType = otb::ImageFileWriter< RGBImageType >;
-	*/
+
 	using FillholeFilterType           = itk::GrayscaleFillholeImageFilter<LabelImageType,LabelImageType>;
 
 	//Output name
@@ -456,13 +456,23 @@ LSImageToGraphScheduler<TInputImage, TOutputGraph>
 	os << this->m_OutputDir << m_LabelImageName << ty << "_" << tx << ".tif";
 
 	auto graphToLabelFilter = GraphToLabelImageFilterType::New();
-	auto grayWriter = WriterType::New();
+	//auto grayWriter = WriterType::New();
+	auto grayWriter = RGBWriterType::New(); // from multithreaded grm
 	auto fillHoleFilter = FillholeFilterType::New();
 
 	grayWriter->SetFileName(os.str());
 	graphToLabelFilter->SetInput(m_Graph);
+
+	LabelToRGBFilterType::Pointer label2colorFilter = LabelToRGBFilterType::New(); // from multithreaded grm
+
 	fillHoleFilter->SetInput(graphToLabelFilter->GetOutput());
-	grayWriter->SetInput(fillHoleFilter->GetOutput());
+	//grayWriter->SetInput(fillHoleFilter->GetOutput());
+
+	// from multithreaded grm
+	label2colorFilter->SetInput(fillHoleFilter->GetOutput());
+	grayWriter->SetInput(label2colorFilter->GetOutput());
+	// from multithreaded grm
+
 	grayWriter->Update();
 }
 

--- a/include/otbObiaLSImageToGraphScheduler.txx
+++ b/include/otbObiaLSImageToGraphScheduler.txx
@@ -4,6 +4,8 @@
 #include "itkRGBPixel.h"
 #include "itkLabelToRGBImageFilter.h"
 
+#include "otbObiaStreamingGraphToImageFilter.h"
+
 namespace otb
 {
 namespace obia
@@ -443,37 +445,43 @@ LSImageToGraphScheduler<TInputImage, TOutputGraph>
 	using GraphToLabelImageFilterType = otb::obia::GraphToLabelImageFilter<TOutputGraph, LabelImageType>;
 	using WriterType = otb::ImageFileWriter< LabelImageType>;
 
-	// FOR COLOR IMAGE
+	/** FOR COLOR IMAGE
 	using RGBPixelType = itk::RGBPixel<unsigned char>;
 	using RGBImageType = otb::Image<RGBPixelType, 2>;
 	using LabelToRGBFilterType = itk::LabelToRGBImageFilter<LabelImageType, RGBImageType>;
 	using RGBWriterType = otb::ImageFileWriter< RGBImageType >;
-
+	*/
 	using FillholeFilterType           = itk::GrayscaleFillholeImageFilter<LabelImageType,LabelImageType>;
 
 	//Output name
-	std::stringstream os;
-	os << this->m_OutputDir << m_LabelImageName << ty << "_" << tx << ".tif";
+	//std::stringstream os;
+	//os << this->m_OutputDir << m_LabelImageName << ty << "_" << tx << ".tif";
 
-	auto graphToLabelFilter = GraphToLabelImageFilterType::New();
-	//auto grayWriter = WriterType::New();
-	auto grayWriter = RGBWriterType::New(); // from multithreaded grm
+	//auto graphToLabelFilter = GraphToLabelImageFilterType::New();
+	auto grayWriter = WriterType::New();
+	
+	/*
 	auto fillHoleFilter = FillholeFilterType::New();
 
 	grayWriter->SetFileName(os.str());
 	graphToLabelFilter->SetInput(m_Graph);
-
-	LabelToRGBFilterType::Pointer label2colorFilter = LabelToRGBFilterType::New(); // from multithreaded grm
-
 	fillHoleFilter->SetInput(graphToLabelFilter->GetOutput());
-	//grayWriter->SetInput(fillHoleFilter->GetOutput());
-
-	// from multithreaded grm
-	label2colorFilter->SetInput(fillHoleFilter->GetOutput());
-	grayWriter->SetInput(label2colorFilter->GetOutput());
-	// from multithreaded grm
-
+	grayWriter->SetInput(fillHoleFilter->GetOutput());
 	grayWriter->Update();
+	*/
+
+	// Streaming label image writer
+  std::stringstream os2;
+  os2 << this->m_OutputDir << m_LabelImageName << ty << "_" << tx << "_stream.tif";
+
+  using StreamingGraph2LabelImgFilterType = otb::obia::StreamingGraphToImageFilter<TOutputGraph, LabelImageType>;
+  auto filter = StreamingGraph2LabelImgFilterType::New();
+  filter->SetInput(m_Graph);
+
+  grayWriter->SetFileName(os2.str());
+  grayWriter->SetInput(filter->GetOutput());
+  grayWriter->Update();
+
 }
 
 } // end of namespace obia

--- a/include/otbObiaStreamingGraphToImageFilter.h
+++ b/include/otbObiaStreamingGraphToImageFilter.h
@@ -1,0 +1,97 @@
+/*
+ * otbStreamingGraphToImageFilter.h
+ *
+ *  Created on: 6 nov. 2017
+ *      Author: cresson
+ */
+
+#ifndef MODULES_REMOTE_LSGRM_INCLUDE_OTBSTREAMINGGRAPHTOIMAGEFILTER_H_
+#define MODULES_REMOTE_LSGRM_INCLUDE_OTBSTREAMINGGRAPHTOIMAGEFILTER_H_
+
+#include "itkImageSource.h"
+#include "itkExceptionObject.h"
+#include "itkImageRegion.h"
+#include "otbObiaGraphToImageFilter.h"
+
+// ITK FillHole filter
+#include "itkGrayscaleFillholeImageFilter.h"
+
+// Boost R-Tree
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/point.hpp>
+#include <boost/geometry/geometries/box.hpp>
+#include <boost/geometry/index/rtree.hpp>
+
+// Contour
+#include "otbObiaContour.h"
+
+// to store queries results
+#include <vector>
+
+// just for output
+#include <iostream>
+#include <boost/foreach.hpp>
+
+namespace bg = boost::geometry;
+namespace bgi = boost::geometry::index;
+
+namespace otb
+{
+namespace obia
+{
+
+template <typename TGraph, typename TLabelImage>
+class StreamingGraphToImageFilter : public GraphToImageFilter<TGraph, TLabelImage>
+{
+public:
+  /** Standard class typedefs. */
+  typedef StreamingGraphToImageFilter                   Self;
+  typedef GraphToImageFilter<TGraph, TLabelImage>       Superclass;
+  typedef itk::SmartPointer<Self>                       Pointer;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(StreamingGraphToImageFilter, GraphToImageFilter);
+
+  /** Typedefs for processing */
+  typedef typename TLabelImage::RegionType              RegionType;
+  typedef typename TLabelImage::IndexType               IndexType;
+  typedef typename TLabelImage::SizeType                SizeType;
+  typedef typename TLabelImage::SpacingType             SpacingType;
+  typedef typename TLabelImage::PointType               PointType;
+  typedef typename TGraph::NodeType                     NodePointerType;
+
+  typedef itk::GrayscaleFillholeImageFilter<TLabelImage,TLabelImage> FillholeFilterType;
+  typedef bg::model::point<float, 2, bg::cs::cartesian> point;
+  typedef bg::model::box<point> box;
+  typedef std::pair<box, unsigned> value;
+
+  /** Compute thr R-Tree */
+  virtual void GenerateRTree();
+
+  /** Prepare image allocation at the first call of the pipeline processing */
+  virtual void GenerateOutputInformation(void);
+
+  /** Does the real work. */
+  virtual void GenerateData();
+
+  /** Overloaded SetInput() method */
+  virtual void SetInput(const TGraph *input);
+
+private:
+
+  bgi::rtree< value, bgi::quadratic<16> > rtree;
+
+};
+
+} // namespace obia
+} // namespace otb
+
+#ifndef OTB_MANUAL_INSTANTIATION
+#include <otbObiaStreamingGraphToImageFilter.txx>
+#endif
+
+#endif /* MODULES_REMOTE_LSGRM_INCLUDE_OTBSTREAMINGGRAPHTOIMAGEFILTER_H_ */
+

--- a/include/otbObiaStreamingGraphToImageFilter.txx
+++ b/include/otbObiaStreamingGraphToImageFilter.txx
@@ -1,0 +1,170 @@
+/*
+ * otbStreamingGraphToImageFilter.txx
+ *
+ *  Created on: 6 nov. 2017
+ *      Author: cresson
+ */
+
+#ifndef MODULES_REMOTE_LSGRM_INCLUDE_OTBSTREAMINGGRAPHTOIMAGEFILTER_TXX_
+#define MODULES_REMOTE_LSGRM_INCLUDE_OTBSTREAMINGGRAPHTOIMAGEFILTER_TXX_
+
+#include <otbObiaStreamingGraphToImageFilter.h>
+
+namespace otb
+{
+namespace obia
+{
+
+template <typename TGraph, typename TLabelImage>
+void
+StreamingGraphToImageFilter<TGraph, TLabelImage>
+::GenerateRTree()
+ {
+  rtree.clear();
+  unsigned int count = 0;
+  auto graph = const_cast< TGraph * >( this->GetInput() );
+  for(auto node = graph->Begin(); node != graph->End(); ++node)
+    {
+    // create a bounding box
+      box b(
+          point(
+              node->m_BoundingBox[0],
+              node->m_BoundingBox[1]),
+          point(
+              node->m_BoundingBox[0] + node->m_BoundingBox[2],
+              node->m_BoundingBox[1] + node->m_BoundingBox[3]));
+
+      // insert new value
+      rtree.insert(std::make_pair(b, count));
+      count++;
+    } // next node
+ }
+
+template <typename TGraph, typename TLabelImage>
+void
+StreamingGraphToImageFilter<TGraph, TLabelImage>
+::SetInput(const TGraph *input)
+ {
+  Superclass::SetInput(input);
+  GenerateRTree();
+ }
+
+template <typename TGraph, typename TLabelImage>
+void
+StreamingGraphToImageFilter<TGraph, TLabelImage>
+::GenerateOutputInformation()
+ {
+
+  // TODO: use appropriate graph methods for accessing origin, spacing, ...
+  auto graph = const_cast< TGraph * >( this->GetInput() );
+
+  // Output Largest Possible Region
+  IndexType index;
+  index.Fill(0);
+  SizeType size;
+  size[0] = graph->GetImageWidth();
+  size[1] = graph->GetImageHeight();
+  PointType origin;
+  origin[0] = graph->GetOriginX();
+  origin[1] = graph->GetOriginY();
+
+  // TODO: add spacing in the graph
+//  SpacingType spacing;
+//  spacing[0] = graph->GetSpacingX();
+//  spacing[1] = graph->GetSpacingY();
+
+  RegionType outputRegion(index, size );
+
+  // Set output informations
+  TLabelImage * outputPtr = this->GetOutput();
+  outputPtr->SetOrigin ( origin );
+//  outputPtr->SetSpacing ( spacing );
+  outputPtr->SetLargestPossibleRegion( outputRegion );
+  outputPtr->SetProjectionRef(graph->GetProjectionRef() );
+ }
+
+
+template <typename TGraph, typename TLabelImage>
+void
+StreamingGraphToImageFilter<TGraph, TLabelImage>
+::GenerateData()
+ {
+  // TODO: use R-tree only if RequestedRegion != LargestPossibleRegion (m_Graph image largest possible region)
+
+  // Allocate the output buffer
+  TLabelImage * outputPtr = this->GetOutput();
+  RegionType outReqRegion = outputPtr->GetRequestedRegion();
+  auto graph = const_cast< TGraph * >( this->GetInput() );
+  outputPtr->SetBufferedRegion(outputPtr->GetRequestedRegion());
+  outputPtr->Allocate();
+
+  // Find nodes intersecting find the output requested region
+  box query_box(
+      point(
+          outReqRegion.GetIndex(0),
+          outReqRegion.GetIndex(1)),
+      point(
+          outReqRegion.GetIndex(0)+outReqRegion.GetSize(0),
+          outReqRegion.GetIndex(1)+outReqRegion.GetSize(1)));
+  std::vector<value> result_s;
+  rtree.query(bgi::intersects(query_box), std::back_inserter(result_s));
+
+  // Retrieve the bounding box of the intersecting nodes (a kind of "Input requested region")
+  box realBBox(query_box);
+  for(auto& res : result_s)
+    {
+      boost::geometry::expand(realBBox, res.first);
+    }
+  IndexType index;
+  index[0] = realBBox.min_corner().get<0>();
+  index[1] = realBBox.min_corner().get<1>();
+  SizeType size;
+  size[0] = realBBox.max_corner().get<0>() - realBBox.min_corner().get<0>();
+  size[1] = realBBox.max_corner().get<1>() - realBBox.min_corner().get<1>();
+  RegionType inputRequestedRegion(index, size);
+
+  // Generate the label image
+  const typename TLabelImage::InternalPixelType noDataLabel = 0;
+  typename TLabelImage::Pointer labelImage = TLabelImage::New();
+  labelImage->SetRegions(inputRequestedRegion);
+  labelImage->Allocate();
+  labelImage->FillBuffer(noDataLabel);
+
+  using LabelImageIterator = itk::ImageRegionIterator<TLabelImage>;
+  LabelImageIterator it(labelImage, inputRequestedRegion);
+
+  // Burn boundaries
+  for(auto& res : result_s)
+    {
+      NodePointerType * node = graph->GetNodeAt(res.second);
+
+      Contour::CoordsSet borderPixels;
+      node->m_Contour.GenerateBorderPixels(borderPixels, graph->GetImageWidth());
+
+      for (auto& pix: borderPixels)
+        {
+          index[0] = pix % graph->GetImageWidth();
+          index[1] = pix / graph->GetImageWidth();
+          labelImage->SetPixel(index, res.second+1); // 0 is the no-data value
+        }
+    }
+
+  // Fill holes
+  // WARNING: the nodes MUST BE in ascending order (e.g. Top --> Down, Left --> Right)
+  // Else the holes cannot be properly filled because of local minimums.
+  typename FillholeFilterType::Pointer fillFilter = FillholeFilterType::New();
+  fillFilter->SetInput(labelImage);
+  fillFilter->Update();
+
+  // Keep just the stable region
+  LabelImageIterator outIt(outputPtr, outReqRegion);
+  LabelImageIterator inIt (fillFilter->GetOutput(), outReqRegion);
+  for (inIt.GoToBegin(), outIt.GoToBegin(); !outIt.IsAtEnd(); ++outIt, ++inIt)
+    outIt.Set(inIt.Get());
+ }
+
+} // namespace obia
+} // namespace otb
+
+#endif
+


### PR DESCRIPTION
**Important updates**
- Up-to-date multithreaded GRM filter: bug during merge fixed, algo routines rewritten using lambdas, partial paralellization of nodes removal
- Up-to-date streaming graph to label image filter (fixed: nodes id start from 1, value 0 is used for background)
- Graph initialization from no-data values is fixed (tested on an image with multiple disconnected no-data regions)

** TODOs (?) **
- _While no-data are handled correctly for the baatz segmentation, we still have the problem of filling the polygons without them (they are handled as a segment with a given id). Only the segment with id 0 is considered as background. A simple way would be to use the input image to mask the label image._
- _Maybe refactor a bit the thread working mechanism inside the GRM Filter (chunks computation, etc)_ 