### PR TITLE
Helper script for Baatz algorithm

### DIFF
--- a/scripts/lsbaatz-helper.py
+++ b/scripts/lsbaatz-helper.py
@@ -63,7 +63,7 @@ for it in range(1,max_iter):
 
    # Check if required memory is higher than available memory
    if used_memory_graph+used_memory_img>mem_per_proc:
-      print("For {} initial iterations: margin={}, \tnot enough memory available".format(it,margin))
+      print("For {} initial iterations: margin={}, \trequired memory={} Mb, not enough memory available".format(it,margin,int(used_memory_graph+used_memory_img)))
    else:
-      print("For {} initial iterations: margin={}, \tmem per node={} Mb (graph={} Mb, img={} Mb)".format(it,margin,used_memory_graph+used_memory_img,used_memory_graph,used_memory_img))
+      print("For {} initial iterations: margin={}, \trequired memory={} Mb".format(it,margin,int(used_memory_graph+used_memory_img)))
 

--- a/scripts/lsbaatz-helper.py
+++ b/scripts/lsbaatz-helper.py
@@ -12,6 +12,9 @@ max_iter = int(sys.argv[4])
 nb_procs = int(sys.argv[5])
 mem_per_proc = int(sys.argv[6])
 
+print("\nImage is {}x{} pixels with {} bands".format(w,h,nb_bands))
+print("System has {} nodes with {} Mb available memory per node".format(nb_procs,mem_per_proc))
+print("Maximum number of initial iterations is {}".format(max_iter)) 
 
 # Compute memory used by a single pixel
 margin = 1.1
@@ -47,7 +50,7 @@ nb_tiles_h = nb_procs/nb_tiles_w
 tile_w = int(math.ceil(float(w)/nb_tiles_w))
 tile_h = int(math.ceil(float(h)/nb_tiles_h))
 
-print("Partionning: {}x{}={} tiles of {}x{} pixels".format(nb_tiles_w,nb_tiles_h,nb_tiles_h*nb_tiles_w,tile_w,tile_h))
+print("\nProposed Partionning: {}x{}={} tiles of {}x{} pixels\n".format(nb_tiles_w,nb_tiles_h,nb_tiles_h*nb_tiles_w,tile_w,tile_h))
 
 # Loop on initial number of iterations
 for it in range(1,max_iter):

--- a/scripts/lsbaatz-helper.py
+++ b/scripts/lsbaatz-helper.py
@@ -1,0 +1,69 @@
+import sys
+import math
+
+if len(sys.argv)!=7:
+   print("Usage: {} nb_bands w h max_iter nb_proc mem_per_proc(Mb)".format(sys.argv[0]))
+   sys.exit(1)
+
+nb_bands = int(sys.argv[1])
+w = int(sys.argv[2])
+h = int(sys.argv[3])
+max_iter = int(sys.argv[4])
+nb_procs = int(sys.argv[5])
+mem_per_proc = int(sys.argv[6])
+
+
+# Compute memory used by a single pixel
+margin = 1.1
+graph_node_size = margin*(4+305+(8*nb_bands)+0.3*4*16 +3*8) # (multithread cost)
+img_node_size = (4+4+4)*nb_bands # gdal buffer + reader buffer + extract ROI buffer
+node_size = graph_node_size + img_node_size
+
+# Image aspect ratio
+ratio = float(w)/float(h)
+
+# Number of pixels per tile
+nb_pixels_per_tile = float(w*h)/nb_procs
+
+# Estimate a target number of divisions in width from number of pixels per tile and aspect ratio
+target_nb_tiles_w = int(w/math.floor(math.sqrt(nb_pixels_per_tile/ratio)))
+
+# Find the factor of nb procs closest to the target number of divisions in width
+dist = abs(target_nb_tiles_w - 1)
+best_factor=1
+
+for factor in range(2,nb_procs+1):
+   if nb_procs % factor == 0:
+      new_dist = abs(target_nb_tiles_w-factor)
+      if new_dist<dist:
+         best_factor=factor
+         dist = new_dist
+
+# Compute number of tiles in w and h
+nb_tiles_w = best_factor
+nb_tiles_h = nb_procs/nb_tiles_w
+
+# Compute tile width and height
+tile_w = int(math.ceil(float(w)/nb_tiles_w))
+tile_h = int(math.ceil(float(h)/nb_tiles_h))
+
+print("Partionning: {}x{}={} tiles of {}x{} pixels".format(nb_tiles_w,nb_tiles_h,nb_tiles_h*nb_tiles_w,tile_w,tile_h))
+
+# Loop on initial number of iterations
+for it in range(1,max_iter):
+
+   # Compute tile size with margins
+   margin = 2**(it+1)-2
+   tile_w_margin = int(math.floor(tile_w + 2*margin))
+   tile_h_margin = int(math.floor(tile_h + 2*margin))
+
+   # Compute memory usage for this margin
+   used_memory_graph = (tile_w_margin+2*margin)*(tile_h_margin+2*margin)*graph_node_size/(10**6)
+   used_memory_img = (tile_w_margin+2*margin)*(tile_h_margin+2*margin)*img_node_size/(10**6)
+
+   # Check if required memory is higher than available memory
+   if used_memory_graph+used_memory_img>mem_per_proc:
+      print("For {} initial iterations: margin={}, \tnot enough memory available".format(it,margin))
+   else:
+      print("For {} initial iterations: margin={}, \tmem per node={} Mb (graph={} Mb, img={} Mb)".format(it,margin,used_memory_graph+used_memory_img,used_memory_graph,used_memory_img))
+


### PR DESCRIPTION
This PR adds a script to help find good configurations for ls baatz algorithm:
```

$ python lsbaatz-helper.py 4 35129 25161 20 100 120000

Image is 35129x25161 pixels with 4 bands
System has 100 nodes with 120000 Mb available memory per node
Maximum number of initial iterations is 20

Proposed Partionning: 10x10=100 tiles of 3513x2517 pixels

For 1 initial iterations: margin=2,     required memory=4183 Mb
For 2 initial iterations: margin=6,     required memory=4229 Mb
For 3 initial iterations: margin=14,    required memory=4320 Mb
For 4 initial iterations: margin=30,    required memory=4507 Mb
For 5 initial iterations: margin=62,    required memory=4893 Mb
For 6 initial iterations: margin=126,   required memory=5710 Mb
For 7 initial iterations: margin=254,   required memory=7530 Mb
For 8 initial iterations: margin=510,   required memory=11908 Mb
For 9 initial iterations: margin=1022,  required memory=23626 Mb
For 10 initial iterations: margin=2046,         required memory=58907 Mb
For 11 initial iterations: margin=4094,         required memory=176840 Mb, not enough memory available
For 12 initial iterations: margin=8190,         required memory=602205 Mb, not enough memory available
For 13 initial iterations: margin=16382,        required memory=2210922 Mb, not enough memory available
For 14 initial iterations: margin=32766,        required memory=8460302 Mb, not enough memory available
For 15 initial iterations: margin=65534,        required memory=33086846 Mb, not enough memory available
For 16 initial iterations: margin=131070,       required memory=130851075 Mb, not enough memory available
For 17 initial iterations: margin=262142,       required memory=520424093 Mb, not enough memory available
For 18 initial iterations: margin=524286,       required memory=2075748374 Mb, not enough memory available
For 19 initial iterations: margin=1048574,      required memory=8291109909 Mb, not enough memory available
```

